### PR TITLE
登壇ご希望の方のボタンが見づらい問題を修正

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,7 +13,7 @@ import Layout from '~/layouts/Vanilla.astro';
       2025/02/01
     </p>
     <div class="flex space-x-4 mb-6 z-10">
-      <a href="https://fortee.jp/burikaigi-2025/speaker/proposal/cfp" class="border-2 border-gray-800 text-black font-bold py-3 px-6 rounded dark:text-white dark:border-white hover:opacity-50 transition">
+      <a href="https://fortee.jp/burikaigi-2025/speaker/proposal/cfp" class="border-2 border-white-800 bg-white font-bold py-3 px-6 rounded dark:text-white dark:border-white hover:opacity-50 transition">
         登壇ご希望の方
       </a>
       <a href="https://fortee.jp/burikaigi-2025/sponsor/form" class="bg-gray-800 hover:bg-gray-700 text-white font-bold py-3 px-6 rounded dark:bg-gray-700 dark:hover:bg-gray-600 hover:opacity-50 transition">


### PR DESCRIPTION
## 概要

「登壇ご希望の方」のボタンのbackgroundが見づらいので白背景で修正しました

## プレビュー

<img width="848" alt="スクリーンショット 2024-10-15 15 47 44" src="https://github.com/user-attachments/assets/d8be6780-3a42-40bb-ae98-bbadfb02a20f">
