### PR TITLE
fix: DarkModeで登壇申込みボタンが見えない問題に対処

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,7 +13,7 @@ import Layout from '~/layouts/Vanilla.astro';
       2025/02/01
     </p>
     <div class="flex space-x-4 mb-6 z-10">
-      <a href="https://fortee.jp/burikaigi-2025/speaker/proposal/cfp" class="border-2 border-white-800 bg-white font-bold py-3 px-6 rounded dark:text-white dark:border-white hover:opacity-50 transition">
+      <a href="https://fortee.jp/burikaigi-2025/speaker/proposal/cfp" class="border-2 border-white-800 bg-white font-bold py-3 px-6 rounded hover:opacity-50 transition">
         登壇ご希望の方
       </a>
       <a href="https://fortee.jp/burikaigi-2025/sponsor/form" class="bg-gray-800 hover:bg-gray-700 text-white font-bold py-3 px-6 rounded dark:bg-gray-700 dark:hover:bg-gray-600 hover:opacity-50 transition">


### PR DESCRIPTION
DarkModeの場合に背景と文字色が同化しているようです
![img_20241016_170609@2x](https://github.com/user-attachments/assets/cbba49d9-ec82-40d6-b249-eca075e56ba9)

ひとまずDarkModeでも同じ見た目になるようにしました
