### PR TITLE
2026年度向け表示

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -20,55 +20,29 @@ const sponsorshipSponsors = sponsors.filter(v => v.type === "後援")
 
 <Layout>
   <div class="bg-gray-900 flex flex-col items-center justify-center relative px-4 py-60">
-    <h1 class="text-5xl md:text-8xl text-white font-bold mb-8 z-10">BuriKaigi 2025</h1>
-    <p class="text-white text-xl md:text-2xl mb-4 z-10">
-      富山県立大学射水キャンパス
-    </p>
+    <h1 class="text-5xl md:text-8xl text-white font-bold mb-8 z-10">BuriKaigi 2026</h1>
     <p class="text-white text-xl md:text-2xl mb-10 z-10">
-      2025/02/01
+      2026年1月
     </p>
-    <div class="flex space-x-4 mb-6 z-10">
-      <a href="https://toyama-eng.connpass.com/event/339471/" class="border-2 border-white-800 bg-white font-bold py-3 px-6 rounded hover:opacity-50 transition">
-        参加申し込み
-      </a>
-      <a href="https://fortee.jp/burikaigi-2025/sponsor/form" class="bg-gray-800 hover:bg-gray-700 text-white font-bold py-3 px-6 rounded dark:bg-gray-700 dark:hover:bg-gray-600 hover:opacity-50 transition">
-        スポンサーのご協力
-      </a>
+    <div class="flex space-x-4 mb-6 z-10 flex-col text-white gap-y-10">
+      <h2 class="font-bold text-4xl ml-4">BuriKaigi 2026、始動。</h2>
+      <div>
+        来年開催予定の <strong>BuriKaigi 2026</strong> に向けて、準備がスタートしました。<br>
+        現在、<strong>CfP（登壇募集）</strong> や <strong>スポンサー募集</strong> の開始に向けて準備を進めています。<br>
+        募集開始までもうしばらくお待ちください。ご興味のある方は、ぜひご検討いただけますと幸いです。
+      </div>
+      <div>
+        公式な最新情報は <a href="https://x.com/burikaigi" target="_blank" rel="noopener noreferrer">X（旧Twitter）の @burikaigi</a> にて順次お知らせします。
+      </div>
     </div>
-    <div class="text-white z-10 mb-10 underline underline-offset-4 hover:opacity-50 transition">
-      <a href="https://fortee.jp/burikaigi-2025/timetable">タイムテーブル(fortee)</a>
+    <div class="text-white z-10 underline underline-offset-4 hover:opacity-50 transition mb-4">
+      <a href="https://fortee.jp/burikaigi-2025/timetable">2025年の様子はこちら(fortee)</a>
     </div>
     <div class="text-white z-10 underline underline-offset-4 hover:opacity-50 transition">
-      <a href="/2024">昨年の様子はこちら</a>
+      <a href="/2024">2024年の様子はこちら</a>
     </div>
     <div class="absolute top-0 left-0 w-full h-full bg-cover bg-center opacity-30"
       style="background-image: url('/images/6ee144801b1e5221410445f7e824b669.png');">
     </div>
   </div>
-
-  <Sponsors sponsors={buriSponsors}
-    title="Buri-Sponsors"
-    titleClassName='mx-auto max-w-2xl text-center font-display text-4xl font-medium tracking-tighter text-gray-900 sm:text-5xl'
-    className="mx-auto mt-20 mx-20 grid max-w-max grid-cols-1 place-content-center gap-x-16 gap-y-12 sm:grid-cols-3 md:gap-x-32 md:gap-x-16"
-  />
-
-  <Sponsors sponsors={gandoSponsors}
-    title="Gando-Sponsors"
-    titleClassName='mx-auto max-w-2xl text-center font-display text-4xl font-medium tracking-tighter text-gray-900 sm:text-5xl'
-    className="mx-auto mt-20 mx-20 grid max-w-max grid-cols-2 place-content-center gap-x-16 gap-y-12 sm:grid-cols-4 md:gap-x-32 md:gap-x-16"
-  />
-
-
-  <Sponsors sponsors={fukuragiSponsors}
-    title="Fukuragi-Sponsors"
-    titleClassName='mx-auto max-w-2xl text-center font-display text-4xl font-medium tracking-tighter text-gray-900 sm:text-5xl'
-    className="mx-auto mt-20 mx-20 grid max-w-max grid-cols-2 place-content-center gap-x-16 gap-y-12 sm:grid-cols-4 md:gap-x-32 md:gap-x-16"
-  />
-
-  <Sponsors sponsors={sponsorshipSponsors}
-    title="後援"
-    titleClassName='mx-auto max-w-2xl text-center font-display text-4xl font-medium tracking-tighter text-gray-900 sm:text-5xl'
-    className="mx-auto mt-20 mx-20 grid max-w-max grid-cols-1 place-content-center gap-x-16 gap-y-12 sm:grid-cols-3 md:gap-x-32 md:gap-x-16 place-items-center"
-  />
-
 </Layout>


### PR DESCRIPTION
2026年度向け表示の取り急ぎ告知用です。
一旦色々無視してテキストをメインにざっくり

<img width="1440" height="980" alt="スクリーンショット 2025-07-12 17 42 56" src="https://github.com/user-attachments/assets/ab643a79-4a1e-4793-a481-482629d5ece3" />
